### PR TITLE
Change PersonalAccessToken to Token

### DIFF
--- a/Tasks/GitHubReleaseV1/operations/Utility.ts
+++ b/Tasks/GitHubReleaseV1/operations/Utility.ts
@@ -12,7 +12,7 @@ export class Utility {
         if (!!githubEndpointObject) {
             tl.debug("Endpoint scheme: " + githubEndpointObject.scheme);
             
-            if (githubEndpointObject.scheme === 'PersonalAccessToken') {
+            if (githubEndpointObject.scheme === 'Token') {
                 githubEndpointToken = githubEndpointObject.parameters.accessToken
             } else if (githubEndpointObject.scheme === 'OAuth'){
                 // scheme: 'OAuth'


### PR DESCRIPTION
The endpoint object scheme being detected when service connection is made from the UI is `Token`, not `PersonalAccessToken`.